### PR TITLE
Iron resize

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,7 @@
+v0.3.0
+=================
+* implemented the iron-resizable-behavior behavior
+
 v0.2.4
 ==================
 * Updated License

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Single-handled slider with step
 ### Layout
 
 The slider will always take the full-width of whatever container it is in.
+If resized or made visible for the first time (if the slider was in a modal for example) then the slider will need to be notified through the iron-resizable-behavior, by manually calling notifyResize() on it for example.  See https://elements.polymer-project.org/elements/iron-resizable-behavior?active=Polymer.IronResizableBehavior
 
 ### Latest Release
 - not released yet!
@@ -69,4 +70,4 @@ The slider will always take the full-width of whatever container it is in.
 - <a href="http://pxc-demos.grc-apps.svc.ice.ge.com/bower_components/px-slider/index.html" target="_blank">API Docs</a>
 
 ### Known Issues
-Sometimes, for multi-handled slider, when you drag one handle to meet the other, the other handle jumps. 
+Sometimes, for multi-handled slider, when you drag one handle to meet the other, the other handle jumps.

--- a/bower.json
+++ b/bower.json
@@ -15,10 +15,10 @@
   ],
   "dependencies": {
     "polymer": "~v1.2.3",
-    "px-theme": "https://github.com/PredixDev/px-theme.git#~0.4.0"
+    "px-theme": "https://github.com/PredixDev/px-theme.git#~0.4.0",
+    "iron-resizable-behavior": "PolymerElements/iron-resizable-behavior#~v1.0.3"
   },
   "devDependencies": {
-    "iron-resizable-behavior": "PolymerElements/iron-resizable-behavior#~v1.0.3",
     "iron-component-page": "PolymerElements/iron-component-page#~v1.1.0",
     "px-forms-design": "https://github.com/PredixDev/px-forms-design.git#~0.3.0",
     "px-starter-kit-design": "https://github.com/PredixDev/px-starter-kit-design.git#~0.4.0",

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "px-slider",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "main": [
     "px-slider.html"
   ],
@@ -18,6 +18,7 @@
     "px-theme": "https://github.com/PredixDev/px-theme.git#~0.4.0"
   },
   "devDependencies": {
+    "iron-resizable-behavior": "PolymerElements/iron-resizable-behavior#~v1.0.3",
     "iron-component-page": "PolymerElements/iron-component-page#~v1.1.0",
     "px-forms-design": "https://github.com/PredixDev/px-forms-design.git#~0.3.0",
     "px-starter-kit-design": "https://github.com/PredixDev/px-starter-kit-design.git#~0.4.0",

--- a/demo-hide-resize.html
+++ b/demo-hide-resize.html
@@ -1,0 +1,93 @@
+<!doctype html>
+
+<html>
+
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>px-slider Demo</title>
+    <!-- Requires Webcomponents.js polyfill is provided by the page for browsers that don't support html imports -->
+    <script src="../webcomponentsjs/webcomponents-lite.min.js"></script>
+
+    <!-- Import custom element. Note: see comment about relative paths to dependencies in the *.html file referenced below -->
+    <link rel="import" href="../px-theme/px-theme.html" />
+    <link rel="import" href="px-slider.html" />
+    <link rel="import" href="demo-nested.html" />
+    <style>
+      html {
+        font-size: .9375rem;
+      }
+    </style>
+  </head>
+
+  <body>
+    <h3>Demo</h3>
+    <p>
+      Although related, examples are /not/ the same as the test fixtures. Tests are tests, examples are examples.
+    </p>
+    <p>
+      All input values are validated and updated according to the constraints (e.g. min, max, step-size).
+    </p>
+
+    <p>
+      Also see the <a href="index.html">documentation</a> and the <a href="test/fixture.html">UI test fixture</a>.
+    </p>
+    <br />
+    <h4>Single Value</h4>
+    <button id="toggle">Show/Hide</button>
+    <button id="sizePlus">Size++</button>
+    <button id="sizeMinus">Size--</button>
+    <div id="mainDiv" style="width: 600px;display:none">
+      <px-slider id="slider" value="50" min="0" max="100">
+      </px-slider>
+      <!-- <h4>Single Value, Greater Precision.  (Step set to 0.001)</h4>
+     <px-slider value="5.556" min="0" max="100" step="0.001">
+     </px-slider>
+       <h4>Single Value, Greater Precision and Custom Step (Step set to 0.04)</h4>
+      <px-slider value="5.44" min="0" max="20" step="0.04">
+      </px-slider>
+      <h4>Range</h4>
+      <div style="width: 600px;">
+        <px-slider start-value="20" end-value="40" min="0" max="60">
+        </px-slider>
+      </div>
+      <h4>Step = 50</h4>
+      <div style="width: 600px;">
+        <px-slider value="150" min="0" max="500" step="50"></px-slider>
+      </div> -->
+    </div>
+  </body>
+
+</html>
+<script>
+  var button = document.getElementById('toggle'),
+      sizePlus = document.getElementById('sizePlus'),
+      sizeMinus = document.getElementById('sizeMinus'),
+      div = document.getElementById('mainDiv'),
+      slider = document.getElementById('slider'),
+      width = 600;
+
+  button.addEventListener('click', function() {
+    if(div.style.display === 'none') {
+      div.style.display = 'block';
+      slider.notifyResize();
+    }
+    else {
+      div.style.display = 'none';
+      slider.notifyResize();
+    }
+  });
+
+  sizePlus.addEventListener('click', function() {
+    width += 50;
+    div.style.width = width + 'px';
+    slider.notifyResize();
+  });
+
+  sizeMinus.addEventListener('click', function() {
+    width -= 50;
+    div.style.width = width + 'px';
+    slider.notifyResize();
+  });
+
+</script>

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "px-slider",
   "author": "General Electric",
   "description": "A Px component",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "private": true,
   "extName": null,
   "repository": {

--- a/px-slider.html
+++ b/px-slider.html
@@ -90,6 +90,8 @@ Allow the user to select a value or range of values within a specified min and m
         // Have to wait for the DOM to finish loading
         // And then refire these
         this.async(function() {
+          // calculate the amount to offset the range on the right for handle width
+          this.offsetForHandleWidth = this._calcOffsetWidth(2);
 
           // move handles into starting position
           this._updateHandle(this.$.startHandle, this.value);
@@ -105,6 +107,8 @@ Allow the user to select a value or range of values within a specified min and m
         this.toggleClass('visuallyhidden', false,  this.$.singleHandle);
 
         this.async(function() {
+          // calculate the amount to offset the range on the right for handle width
+          this.offsetForHandleWidth = this._calcOffsetWidth(22);
 
           // move handle into initial position
           this._updateHandle(this.$.singleHandle, this.value);
@@ -193,12 +197,14 @@ Allow the user to select a value or range of values within a specified min and m
      * when they know the slider has been resized or made visible.
      */
     _onIronResize: function() {
+      var slider = this;
 
       //debounce resize events
       if (slider.debounce) {
         slider.debounce(
           'slider_resize', function() {
-            console.log('resize');
+            var handleWidth  = this.range ? 2 : 22;
+            this.offsetForHandleWidth = this._calcOffsetWidth(handleWidth);
             if(this.range) {
               this._updateHandle(this.$.startHandle, this.value);
               this._updateHandle(this.$.endHandle, this.endValue);
@@ -447,9 +453,6 @@ Allow the user to select a value or range of values within a specified min and m
      *
      */
     _updateHandle: function(handle, value) {
-      // we need to recalc the container size every time in case its width has changed
-      var handleSize = this.range ? 2 : 22;
-      this.offsetForHandleWidth = this._calcOffsetWidth(handleSize);
 
       // Determine new x position form value
       var newPos = this._translateValueToPosition(value);

--- a/px-slider.html
+++ b/px-slider.html
@@ -5,6 +5,7 @@
     See https://github.com/jreichenberg/grunt-dep-serve#why-do-we-need-this
 -->
 <link rel="import" href="../polymer/polymer.html" />
+<link rel="import" href="../iron-resizable-behavior/iron-resizable-behavior.html"/>
 <link rel="import" href="px-handle.html" />
 <link rel="import" href="px-handle-multi.html" />
 
@@ -41,6 +42,10 @@ Allow the user to select a value or range of values within a specified min and m
   Polymer({
 
     is: 'px-slider',
+
+    behaviors: [
+      Polymer.IronResizableBehavior
+    ],
 
     ready: function() {
       // Must have min and max values
@@ -85,8 +90,6 @@ Allow the user to select a value or range of values within a specified min and m
         // Have to wait for the DOM to finish loading
         // And then refire these
         this.async(function() {
-          // calc the amount to offset the range on the right to account for handle width
-          this.offsetForHandleWidth = this._calcOffsetWidth(2);
 
           // move handles into starting position
           this._updateHandle(this.$.startHandle, this.value);
@@ -102,8 +105,6 @@ Allow the user to select a value or range of values within a specified min and m
         this.toggleClass('visuallyhidden', false,  this.$.singleHandle);
 
         this.async(function() {
-          // calculate the amount to offset the range on the right for handle width
-          this.offsetForHandleWidth = this._calcOffsetWidth(22);
 
           // move handle into initial position
           this._updateHandle(this.$.singleHandle, this.value);
@@ -181,6 +182,32 @@ Allow the user to select a value or range of values within a specified min and m
         value: false,
         reflect: true
       }
+    },
+
+    listeners: {
+      'iron-resize': '_onIronResize'
+    },
+
+    /**
+     * This will be called by the parents through the iron-resizable-behavior
+     * when they know the slider has been resized or made visible.
+     */
+    _onIronResize: function() {
+
+      //debounce resize events
+      if (slider.debounce) {
+        slider.debounce(
+          'slider_resize', function() {
+            console.log('resize');
+            if(this.range) {
+              this._updateHandle(this.$.startHandle, this.value);
+              this._updateHandle(this.$.endHandle, this.endValue);
+            }
+            else {
+              this._updateHandle(this.$.singleHandle, this.value);
+            }
+          }, 50);
+        }
     },
     /**
      * As an overview, there are functions for:
@@ -420,6 +447,10 @@ Allow the user to select a value or range of values within a specified min and m
      *
      */
     _updateHandle: function(handle, value) {
+      // we need to recalc the container size every time in case its width has changed
+      var handleSize = this.range ? 2 : 22;
+      this.offsetForHandleWidth = this._calcOffsetWidth(handleSize);
+
       // Determine new x position form value
       var newPos = this._translateValueToPosition(value);
 


### PR DESCRIPTION
add iron-resize behavior to slider so it can recalculate the handle position appropriately when being shown for the first time (for example in a modal) or just resized by a parent.
the slider will need to be notified manually (notifyResize()) or through an iron-resize event

fixing issue #1 

@runn-vermel @ek @mdwragg 