### PR TITLE
Delete unnecessary hash in polymer version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,7 @@
     "examples"
   ],
   "dependencies": {
-    "polymer": "#1.9 - 2",
+    "polymer": "1.9 - 2",
     "px-d3-imports": "^3.0.0",
     "iron-resizable-behavior": "^2.0.0",
     "px-number-formatter": "^4.0.0",


### PR DESCRIPTION
I assume it's either "Polymer/polymer#1.9 - 2" or just "1.9 - 2". I ran into some problems deploying this component to webjar, due to this error.

P/s: I have signed the CLA.
